### PR TITLE
fix: tighten auth and magic link rate limits

### DIFF
--- a/.changeset/tighten-auth-magic-rate-limits.md
+++ b/.changeset/tighten-auth-magic-rate-limits.md
@@ -1,0 +1,6 @@
+---
+"intervo-backend": patch
+---
+
+Tighten rate limiting thresholds for authentication and magic link endpoints to match documented expectations.
+

--- a/packages/intervo-backend/lib/rateLimitMiddleware.js
+++ b/packages/intervo-backend/lib/rateLimitMiddleware.js
@@ -11,7 +11,7 @@ const apiLimiter = rateLimit({
 // More strict rate limiter for authentication endpoints
 const authLimiter = rateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour
-  max: 15, // Limit each IP to 5 requests per windowMs
+  max: 5, // Limit each IP to 5 requests per windowMs
   standardHeaders: true,
   message: { message: 'Too many authentication attempts, please try again later.' }
 });
@@ -19,7 +19,7 @@ const authLimiter = rateLimit({
 // Specific rate limiter for magic link endpoints
 const magicLinkLimiter = rateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour
-  max: 5, // Limit each IP to 3 magic link requests per hour
+  max: 3, // Limit each IP to 3 magic link requests per hour
   standardHeaders: true,
   message: { message: 'Too many magic link requests, please try again later.' },
   keyGenerator: (req) => {


### PR DESCRIPTION
## Summary
- align rate limiter configuration with documented request caps
- add changeset for intervo-backend

## Testing
- `npm test --workspace=intervo-backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894f6f0c334832194908466e685c2af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated rate limiting thresholds for authentication and magic link endpoints to allow fewer requests per hour, providing stricter control over request rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->