### PR TITLE
feat: add generic HTTP tool for external API integration

### DIFF
--- a/packages/intervo-backend/agents/BaseAgent.js
+++ b/packages/intervo-backend/agents/BaseAgent.js
@@ -443,7 +443,7 @@ class BaseAgent {
   async executeTool(tool, intent, input, params = {}) {
     // This method determines what operation to call on the tool
     // based on the intent and input
-    const operation = this.mapIntentToOperation(intent, input, tool.type);
+    const operation = this.mapIntentToOperation(intent, input, tool.type, tool);
     
     try {
       const result = await tool.execute(operation, params);
@@ -475,7 +475,7 @@ class BaseAgent {
     }
   }
 
-  mapIntentToOperation(intent, input, toolType) {
+  mapIntentToOperation(intent, input, toolType, tool = null) {
     // Map intents to specific tool operations
     const inputLower = input.toLowerCase();
     
@@ -511,7 +511,21 @@ class BaseAgent {
       }
       return 'get_user_profile'; // Default
     }
-    
+
+    if (toolType === 'http' || toolType === 'api' || toolType === 'rest') {
+      // Generic HTTP tools define operations with optional keywords
+      if (tool && tool.operations) {
+        for (const [opName, opConfig] of Object.entries(tool.operations)) {
+          const keywords = opConfig.keywords || [];
+          if (keywords.some(k => inputLower.includes(k.toLowerCase()))) {
+            return opName;
+          }
+        }
+        return Object.keys(tool.operations)[0] || 'default';
+      }
+      return 'default';
+    }
+
     return 'default';
   }
 

--- a/packages/intervo-backend/package.json
+++ b/packages/intervo-backend/package.json
@@ -27,6 +27,7 @@
     "@langchain/openai": "^0.4.4",
     "@modelcontextprotocol/sdk": "^1.15.0",
     "assemblyai": "^4.9.0",
+    "axios": "^1.8.3",
     "audio-buffer-utils": "^5.1.2",
     "aws-sdk": "^2.1691.0",
     "chromadb": "^1.10.4",

--- a/packages/intervo-backend/services/ToolManager.js
+++ b/packages/intervo-backend/services/ToolManager.js
@@ -1,4 +1,5 @@
 import { MCPTool } from '../tools/MCPTool.js';
+import { HTTPTool } from '../tools/HTTPTool.js';
 
 class ToolManager {
   constructor() {
@@ -61,8 +62,12 @@ class ToolManager {
         // Inject credentials if available
         const enhancedConfig = this.enhanceToolConfigWithCredentials(toolConfig);
         tool = MCPTool.createTool(enhancedConfig);
+      } else if (this.isHTTPTool(toolConfig)) {
+        // Generic REST/HTTP tool
+        const enhancedConfig = this.enhanceToolConfigWithCredentials(toolConfig);
+        tool = new HTTPTool(enhancedConfig);
       } else {
-        // Handle other tool types here in the future
+        // Fallback generic tool
         tool = this.createGenericTool(toolConfig);
       }
 
@@ -104,6 +109,11 @@ class ToolManager {
   isMCPTool(toolConfig) {
     const mcpTypes = ['calendly', 'google-calendar', 'outlook-calendar', 'mcp'];
     return mcpTypes.includes(toolConfig.type) || toolConfig.protocol === 'mcp';
+  }
+
+  isHTTPTool(toolConfig) {
+    const httpTypes = ['http', 'rest', 'api'];
+    return httpTypes.includes(toolConfig.type) || toolConfig.protocol === 'rest';
   }
 
   createGenericTool(toolConfig) {

--- a/packages/intervo-backend/tools/HTTPTool.js
+++ b/packages/intervo-backend/tools/HTTPTool.js
@@ -1,0 +1,76 @@
+import axios from 'axios';
+
+class HTTPTool {
+  constructor(config) {
+    this.name = config.name;
+    this.type = config.type || 'http';
+    this.baseUrl = config.baseUrl || config.serverUrl || '';
+    this.description = config.description;
+    this.operations = config.operations || {};
+    this.headers = config.headers || {};
+    this.credentials = config.credentials || {};
+    this.keywords = config.keywords || [];
+    this.isHealthy = true; // Assume healthy by default
+  }
+
+  getPrimaryCredential() {
+    return this.credentials.apiKey || this.credentials.accessToken;
+  }
+
+  canHandle(intent, input) {
+    if (!this.keywords.length) return false;
+    const lower = input.toLowerCase();
+    return this.keywords.some(k => lower.includes(k.toLowerCase()));
+  }
+
+  buildUrl(path = '') {
+    if (!path.startsWith('http')) {
+      const base = this.baseUrl.replace(/\/$/, '');
+      path = path.replace(/^\//, '');
+      return `${base}/${path}`;
+    }
+    return path;
+  }
+
+  // Replace template variables in object values
+  substitute(template = {}, params = {}) {
+    const result = {};
+    for (const [key, value] of Object.entries(template)) {
+      if (typeof value === 'string') {
+        result[key] = value.replace(/\{\{(.*?)\}\}/g, (_, p1) => params[p1.trim()] ?? '');
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  async execute(operation, params = {}) {
+    const op = this.operations[operation];
+    if (!op) {
+      throw new Error(`Operation ${operation} not configured`);
+    }
+
+    const method = (op.method || 'GET').toUpperCase();
+    const url = this.buildUrl(op.url || op.path || '');
+    const headers = { ...this.headers, ...(op.headers || {}) };
+
+    const credential = this.getPrimaryCredential();
+    if (credential && op.authHeader) {
+      headers[op.authHeader] = credential;
+    }
+
+    const config = { method, url, headers };
+
+    if (method === 'GET') {
+      config.params = { ...this.substitute(op.params, params), ...params };
+    } else {
+      config.data = { ...this.substitute(op.data, params), ...params };
+    }
+
+    const response = await axios(config);
+    return response.data;
+  }
+}
+
+export { HTTPTool };

--- a/packages/intervo-frontend/src/app/(workspace)/[workspaceid]/agent/(agent)/[slug]/playground/canvas/components/AgentCapabilities.jsx
+++ b/packages/intervo-frontend/src/app/(workspace)/[workspaceid]/agent/(agent)/[slug]/playground/canvas/components/AgentCapabilities.jsx
@@ -16,6 +16,7 @@ import IntentDialog from "./IntentDialog";
 import IntentItem from "./IntentItem";
 import FunctionDialog from "./FunctionDialog";
 import FunctionItem from "./FunctionItem";
+import ToolConfigDialog from "./ToolConfigDialog";
 import { Card, CardContent } from "@/components/ui/card";
 import { usePlayground } from "@/context/AgentContext";
 
@@ -43,6 +44,7 @@ const AgentCapabilities = ({ agentData, onSave }) => {
 
   const { tools, fetchTools, aiConfig } = usePlayground();
   const [selectedTool, setSelectedTool] = useState(null);
+  const [isToolDialogOpen, setIsToolDialogOpen] = useState(false);
 
   useEffect(() => {
     if (agentData?.intents) {
@@ -215,6 +217,9 @@ const AgentCapabilities = ({ agentData, onSave }) => {
       onSave({
         tools: [selected._id],
       });
+      if (selected.requiredFields?.length) {
+        setIsToolDialogOpen(true);
+      }
     }
   };
   return (
@@ -276,31 +281,47 @@ const AgentCapabilities = ({ agentData, onSave }) => {
         <div className="space-y-1 flex-1">
           <h3 className="text-xs font-medium text-gray-900">Functions</h3>
           <p className="text-xs text-gray-600">
-            Add functions to extend the agent&apos;s capabilities
+            Connect external tools to extend the agent&apos;s capabilities
           </p>
-          {!selectedTool && (
-            <p className="text-xs text-gray-500 italic">
-              No functions added yet
-            </p>
-          )}
-          {selectedTool && (
-            <div className="text-xs text-gray-700 mt-2">
-              {selectedTool.name}
-            </div>
-          )}
+          <div className="flex items-center gap-2 mt-2">
+            <Select
+              value={selectedTool ? selectedTool._id : ""}
+              onValueChange={handleToolChange}
+            >
+              <SelectTrigger className="w-[180px]">
+                <SelectValue placeholder="Select a tool" />
+              </SelectTrigger>
+              <SelectContent>
+                {tools?.map((tool) => (
+                  <SelectItem key={tool._id} value={tool._id}>
+                    {tool.name}
+                  </SelectItem>
+                ))}
+                {selectedTool && <SelectItem value="remove">Remove</SelectItem>}
+              </SelectContent>
+            </Select>
+            {selectedTool && selectedTool.requiredFields?.length > 0 && (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => setIsToolDialogOpen(true)}
+              >
+                Configure
+              </Button>
+            )}
+          </div>
         </div>
-        <Button
-          type="button"
-          onClick={() => {
-            /* We'll define this later */
-          }}
-          size="sm"
-          variant="outline"
-          className="text-xs ml-3"
-        >
-          Add Function
-        </Button>
       </div>
+
+      {selectedTool && (
+        <ToolConfigDialog
+          isOpen={isToolDialogOpen}
+          onClose={() => setIsToolDialogOpen(false)}
+          onSave={(config) => onSave({ tools: [selectedTool._id], config })}
+          tool={selectedTool}
+        />
+      )}
 
       <IntentDialog
         isOpen={dialogState.isOpen}

--- a/packages/intervo-frontend/src/app/(workspace)/[workspaceid]/agent/(agent)/[slug]/playground/canvas/components/ToolConfigDialog.jsx
+++ b/packages/intervo-frontend/src/app/(workspace)/[workspaceid]/agent/(agent)/[slug]/playground/canvas/components/ToolConfigDialog.jsx
@@ -50,7 +50,7 @@ const ToolConfigDialog = ({ isOpen, onClose, onSave, tool }) => {
     const toolConfig = {
       name: tool.type,
       type: tool.type,
-      serverUrl: `http://localhost:${tool.serverPort}`,
+      serverUrl: tool.serverUrl || (tool.serverPort ? `http://localhost:${tool.serverPort}` : ""),
       config: formData,
     };
 
@@ -99,7 +99,7 @@ const ToolConfigDialog = ({ isOpen, onClose, onSave, tool }) => {
           <Button variant="outline" onClick={handleClose}>
             Cancel
           </Button>
-          <Button onClick={handleSave}>Save Tool</Button>
+          <Button onClick={handleSave}>Connect Tool</Button>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- add reusable `HTTPTool` for invoking REST APIs
- allow `ToolManager` and agents to register and use HTTP tools
- expose axios dependency for backend
- enable frontend agents to select and configure tools via a dropdown and dialog

## Testing
- `npm test --workspace=intervo-backend` *(fails: Error: no test specified)*
- `npm test --workspace=intervo-frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894f7cd6b988321a3899d2dab316cf4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HTTP-based tools, enabling integration and execution of HTTP, REST, or API operations.
  * Introduced a new configuration dialog for tools in the agent capabilities section, allowing users to configure tools with required fields directly from the UI.

* **Improvements**
  * Enhanced tool selection UI with a dropdown and a "Configure" button for tools needing configuration.
  * Updated tool configuration dialog to use the tool's server URL if available and improved button labeling for clarity.

* **Chores**
  * Added the axios library as a new backend dependency for HTTP operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->